### PR TITLE
Fix: Refactor Sequelize associations and correct HTML hrefs

### DIFF
--- a/models/Artisan.js
+++ b/models/Artisan.js
@@ -1,7 +1,7 @@
 const { DataTypes } = require('sequelize');
 const sequelize = require('../config/db');
-const User = require('./User'); // Import User model
-const Product = require('./Product'); // Import Product model
+// const User = require('./User'); // Import User model
+// const Product = require('./Product'); // Import Product model
 
 const Artisan = sequelize.define('Artisan', {
   id: {
@@ -47,7 +47,7 @@ const Artisan = sequelize.define('Artisan', {
 });
 
 // Define associations
-Artisan.belongsTo(User, { foreignKey: 'userId' });
-Artisan.hasMany(Product, { foreignKey: 'artisanId' });
+// Artisan.belongsTo(User, { foreignKey: 'userId' });
+// Artisan.hasMany(Product, { foreignKey: 'artisanId' });
 
 module.exports = Artisan;

--- a/models/Cart.js
+++ b/models/Cart.js
@@ -1,7 +1,7 @@
 const { DataTypes } = require('sequelize');
 const sequelize = require('../config/db');
-const User = require('./User');
-const Product = require('./Product');
+// const User = require('./User');
+// const Product = require('./Product');
 
 const Cart = sequelize.define('Cart', {
   id: {
@@ -44,7 +44,7 @@ const Cart = sequelize.define('Cart', {
 });
 
 // Define associations
-Cart.belongsTo(User, { foreignKey: 'userId' });
-Cart.belongsTo(Product, { foreignKey: 'productId' });
+// Cart.belongsTo(User, { foreignKey: 'userId' });
+// Cart.belongsTo(Product, { foreignKey: 'productId' });
 
 module.exports = Cart;

--- a/models/Order.js
+++ b/models/Order.js
@@ -1,7 +1,7 @@
 const { DataTypes } = require('sequelize');
 const sequelize = require('../config/db');
-const User = require('./User'); // Import User model for association
-const OrderItem = require('./OrderItem'); // Import OrderItem model for association
+// const User = require('./User'); // Import User model for association
+// const OrderItem = require('./OrderItem'); // Import OrderItem model for association
 
 const Order = sequelize.define('Order', {
   id: {
@@ -49,7 +49,7 @@ const Order = sequelize.define('Order', {
 });
 
 // Define associations
-Order.belongsTo(User, { foreignKey: 'userId' });
-Order.hasMany(OrderItem, { foreignKey: 'orderId' });
+// Order.belongsTo(User, { foreignKey: 'userId' });
+// Order.hasMany(OrderItem, { foreignKey: 'orderId' });
 
 module.exports = Order;

--- a/models/OrderItem.js
+++ b/models/OrderItem.js
@@ -1,7 +1,7 @@
 const { DataTypes } = require('sequelize');
 const sequelize = require('../config/db');
-const Order = require('./Order');
-const Product = require('./Product');
+// const Order = require('./Order');
+// const Product = require('./Product');
 
 const OrderItem = sequelize.define('OrderItem', {
   id: {
@@ -48,7 +48,7 @@ const OrderItem = sequelize.define('OrderItem', {
 });
 
 // Define associations
-OrderItem.belongsTo(Order, { foreignKey: 'orderId' });
-OrderItem.belongsTo(Product, { foreignKey: 'productId' });
+// OrderItem.belongsTo(Order, { foreignKey: 'orderId' });
+// OrderItem.belongsTo(Product, { foreignKey: 'productId' });
 
 module.exports = OrderItem;

--- a/models/Product.js
+++ b/models/Product.js
@@ -1,6 +1,6 @@
 const { DataTypes } = require('sequelize');
 const sequelize = require('../config/db');
-const Artisan = require('./Artisan'); // Import Artisan model
+// const Artisan = require('./Artisan'); // Import Artisan model
 // Cart and OrderItem will be imported later to avoid circular dependencies if they also import Product
 // For now, we'll use sequelize.models for them in associations if needed immediately,
 // but ideally, associations are defined after all models are defined and registered.
@@ -57,7 +57,7 @@ const Product = sequelize.define('Product', {
 });
 
 // Define associations
-Product.belongsTo(Artisan, { foreignKey: 'artisanId' });
+// Product.belongsTo(Artisan, { foreignKey: 'artisanId' });
 
 // Associations to Cart and OrderItem will be added after ensuring those models are defined
 // to avoid circular dependency issues with require().
@@ -72,8 +72,8 @@ module.exports = Product;
 // Let's try requiring them and see if the environment handles it.
 // If not, using sequelize.models within the association is the fallback.
 
-const Cart = require('./Cart');
-const OrderItem = require('./OrderItem');
+// const Cart = require('./Cart');
+// const OrderItem = require('./OrderItem');
 
-Product.hasMany(Cart, { foreignKey: 'productId' });
-Product.hasMany(OrderItem, { foreignKey: 'productId' });
+// Product.hasMany(Cart, { foreignKey: 'productId' });
+// Product.hasMany(OrderItem, { foreignKey: 'productId' });

--- a/models/User.js
+++ b/models/User.js
@@ -40,12 +40,12 @@ const User = sequelize.define('User', {
 // Associations
 // Need to require models here to avoid circular dependencies if they also require User.
 // This is often done in a separate association setup file or after all models are defined.
-const Cart = require('./Cart');
-const Order = require('./Order');
-const Artisan = require('./Artisan');
+// const Cart = require('./Cart');
+// const Order = require('./Order');
+// const Artisan = require('./Artisan');
 
-User.hasMany(Cart, { foreignKey: 'userId' });
-User.hasMany(Order, { foreignKey: 'userId' });
-User.hasOne(Artisan, { foreignKey: 'userId' }); // An artisan profile is linked to a user account
+// User.hasMany(Cart, { foreignKey: 'userId' });
+// User.hasMany(Order, { foreignKey: 'userId' });
+// User.hasOne(Artisan, { foreignKey: 'userId' }); // An artisan profile is linked to a user account
 
 module.exports = User;

--- a/public/about.html
+++ b/public/about.html
@@ -42,17 +42,17 @@
       </div>
       <div class="flex flex-1 justify-end gap-8">
         <div class="flex items-center gap-9">
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Shop</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="catalogo.html">Shop</a>
           <a class="text-[#141414] text-sm font-medium leading-normal" href="#">About</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Contact</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="contatti.html">Contact</a>
         </div>
         <div class="flex gap-2">
-          <button
+          <a href="login.html"
                   class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-bold leading-normal tracking-[0.015em]"
           >
             <span class="truncate">Sign in</span>
-          </button>
-          <button
+          </a>
+          <a href="#"
                   class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
           >
             <div class="text-[#141414]" data-icon="MagnifyingGlass" data-size="20px" data-weight="regular">
@@ -62,8 +62,8 @@
                 ></path>
               </svg>
             </div>
-          </button>
-          <button
+          </a>
+          <a href="carrello.html"
                   class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
           >
             <div class="text-[#141414]" data-icon="ShoppingBag" data-size="20px" data-weight="regular">
@@ -73,7 +73,7 @@
                 ></path>
               </svg>
             </div>
-          </button>
+          </a>
         </div>
       </div>
     </header>
@@ -178,9 +178,9 @@
       <div class="flex max-w-[960px] flex-1 flex-col">
         <footer class="flex flex-col gap-6 px-5 py-10 text-center @container">
           <div class="flex flex-wrap items-center justify-center gap-6 @[480px]:flex-row @[480px]:justify-around">
-            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="#">Privacy Policy</a>
-            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="#">Terms of Service</a>
-            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="#">Contact Us</a>
+            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="privacy.html">Privacy Policy</a>
+            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="terms.html">Terms of Service</a>
+            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="contatti.html">Contact Us</a>
           </div>
           <div class="flex flex-wrap justify-center gap-4">
             <a href="#">

--- a/public/aggiungiProdotto.html
+++ b/public/aggiungiProdotto.html
@@ -28,16 +28,16 @@
       </div>
       <div class="flex flex-1 justify-end gap-8">
         <div class="flex items-center gap-9">
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Dashboard</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Orders</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Products</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="dashboard.html">Dashboard</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="ordiniArtigiano.html">Orders</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="magazzino.html">Products</a>
           <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Analytics</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Profile</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="dashboard.html">Profile</a>
         </div>
-        <div
+        <a href="dashboard.html"
                 class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
                 style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCa3-oB19_5jRYxnqQ_vveVXPDR2yXhA0vEkUXXt4vzylrxca_CJOGFv2arYcY2Hk4RV7XhaekvIoY_xgj5cql1D7txraYOaaMqqOh7PWZw0e2AoHw7V8qalXt16h_lEV_iLsU8WsTOE9KOyNQYjEwA0YJ07Ft9q1GVK9MlLwp_lOLiVCIUFL3YqLgZwTp0Lch-02t1IQb9gSy6bFVo9MruU0sn7GnlKU3vCz7o9R1uHerINJEWueLQu-QA7Hrd_mdrxkXseta5qtU");'
-        ></div>
+        ></a>
       </div>
     </header>
     <div class="px-40 flex flex-1 justify-center py-5">

--- a/public/carrello.html
+++ b/public/carrello.html
@@ -29,7 +29,7 @@
               <h1 class="text-[#141414] text-base font-medium leading-normal">Sophia Carter</h1>
             </div>
             <div class="flex flex-col gap-2">
-              <div class="flex items-center gap-3 px-3 py-2">
+              <a href="index.html" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="House" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -38,8 +38,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Home</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="catalogo.html" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="ShoppingBag" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -48,8 +48,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Shop</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2 rounded-lg bg-[#f2f2f2]">
+              </a>
+              <a href="carrello.html" class="flex items-center gap-3 px-3 py-2 rounded-lg bg-[#f2f2f2]">
                 <div class="text-[#141414]" data-icon="Truck" data-size="24px" data-weight="fill">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -58,8 +58,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Orders</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="#" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="Heart" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -68,8 +68,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Favorites</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="login.html" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="User" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -78,7 +78,7 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Profile</p>
-              </div>
+              </a>
             </div>
           </div>
         </div>

--- a/public/catalogo.html
+++ b/public/catalogo.html
@@ -42,10 +42,10 @@
                     <h2 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em]">Crafted</h2>
                 </div>
                 <div class="flex items-center gap-9">
-                    <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Home</a>
+                    <a class="text-[#141414] text-sm font-medium leading-normal" href="index.html">Home</a>
                     <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Categories</a>
-                    <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Artisans</a>
-                    <a class="text-[#141414] text-sm font-medium leading-normal" href="#">About</a>
+                    <a class="text-[#141414] text-sm font-medium leading-normal" href="magazzino.html">Artisans</a>
+                    <a class="text-[#141414] text-sm font-medium leading-normal" href="about.html">About</a>
                 </div>
             </div>
             <div class="flex flex-1 justify-end gap-8">
@@ -71,7 +71,7 @@
                     </div>
                 </label>
                 <div class="flex gap-2">
-                    <button
+                    <a href="#"
                             class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
                     >
                         <div class="text-[#141414]" data-icon="Heart" data-size="20px" data-weight="regular">
@@ -81,8 +81,8 @@
                                 ></path>
                             </svg>
                         </div>
-                    </button>
-                    <button
+                    </a>
+                    <a href="carrello.html"
                             class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
                     >
                         <div class="text-[#141414]" data-icon="ShoppingBag" data-size="20px" data-weight="regular">
@@ -92,12 +92,12 @@
                                 ></path>
                             </svg>
                         </div>
-                    </button>
+                    </a>
                 </div>
-                <div
+                <a href="login.html"
                         class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
                         style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuDsnpTOPCmtwI-XcR-ElAoN-77R1DSX1YXYk1wMStAq76mN_8Q0JekJ0Uih9EiIUP41jFyyrp-O4OQYLWCY0M92Am2QMJY5PuxcUYm86hztVlmR312Wx5R-jAqy6YfWFYSmMprnCtOUHsDQaEbR2ukDQDU6NLwEI-TGYkDLMigQZC8CB-KMBDF1TsotP-UcF5CRuLAY-HOaPP3fDphfOIx_WD6cqJFAK5ORqUcDfFTMxbxuSTuvjhCIXs3od7MUPVDB8pALN0nxU4o");'
-                ></div>
+                ></a>
             </div>
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">
@@ -219,9 +219,9 @@
             <div class="flex max-w-[960px] flex-1 flex-col">
                 <footer class="flex flex-col gap-6 px-5 py-10 text-center @container">
                     <div class="flex flex-wrap items-center justify-center gap-6 @[480px]:flex-row @[480px]:justify-around">
-                        <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="#">Terms of Service</a>
-                        <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="#">Privacy Policy</a>
-                        <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="#">Contact Us</a>
+                        <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="terms.html">Terms of Service</a>
+                        <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="privacy.html">Privacy Policy</a>
+                        <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="contatti.html">Contact Us</a>
                     </div>
                     <p class="text-[#757575] text-base font-normal leading-normal">@2024 Crafted. All rights reserved.</p>
                 </footer>

--- a/public/checkout.html
+++ b/public/checkout.html
@@ -44,15 +44,15 @@
       </div>
       <div class="flex flex-1 justify-end gap-8">
         <div class="flex items-center gap-9">
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">New Arrivals</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Best Sellers</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="catalogo.html">New Arrivals</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="catalogo.html">Best Sellers</a>
           <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Home Decor</a>
           <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Jewelry</a>
           <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Clothing</a>
           <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Gifts</a>
         </div>
         <div class="flex gap-2">
-          <button
+          <a href="#"
                   class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
           >
             <div class="text-[#141414]" data-icon="MagnifyingGlass" data-size="20px" data-weight="regular">
@@ -62,8 +62,8 @@
                 ></path>
               </svg>
             </div>
-          </button>
-          <button
+          </a>
+          <a href="#"
                   class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
           >
             <div class="text-[#141414]" data-icon="Heart" data-size="20px" data-weight="regular">
@@ -73,18 +73,18 @@
                 ></path>
               </svg>
             </div>
-          </button>
+          </a>
         </div>
-        <div
+        <a href="login.html"
                 class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
                 style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuB8HwlokHljmQY1V53lPnB3B9GXPqfRJeBoVr7N216npboy7GRKZ4sHhOl8Wzx4_gt_hx11GCE83oeRHi4w3DExVu86hUeGVVcrhigqsyDOhokpBd9IUp8INZ1KlHjVu3CSTRirDjI6kJTVRZp56Zbe6TCVjcZKjiQf2QtCJbePXQeATr_eIfiCfU9yUWaQX8sSMS8edmErNeOiiiOTkpWUd7x4SnCJSodw_6h8oV2JEGE9tJNSV7IVB_qnRCzTOzLwiHtBLUfbeNs");'
-        ></div>
+        ></a>
       </div>
     </header>
     <div class="px-40 flex flex-1 justify-center py-5">
       <div class="layout-content-container flex flex-col w-[512px] max-w-[512px] py-5 max-w-[960px] flex-1">
         <div class="flex flex-wrap gap-2 p-4">
-          <a class="text-[#757575] text-base font-medium leading-normal" href="#">Cart</a>
+          <a class="text-[#757575] text-base font-medium leading-normal" href="carrello.html">Cart</a>
           <span class="text-[#757575] text-base font-medium leading-normal">/</span>
           <span class="text-[#141414] text-base font-medium leading-normal">Checkout</span>
         </div>

--- a/public/contatti.html
+++ b/public/contatti.html
@@ -42,13 +42,13 @@
       </div>
       <div class="flex flex-1 justify-end gap-8">
         <div class="flex items-center gap-9">
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Home</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Shop</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">About</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Contact</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="index.html">Home</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="catalogo.html">Shop</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="about.html">About</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="contatti.html">Contact</a>
         </div>
         <div class="flex gap-2">
-          <button
+          <a href="#"
                   class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
           >
             <div class="text-[#141414]" data-icon="MagnifyingGlass" data-size="20px" data-weight="regular">
@@ -58,8 +58,8 @@
                 ></path>
               </svg>
             </div>
-          </button>
-          <button
+          </a>
+          <a href="carrello.html"
                   class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
           >
             <div class="text-[#141414]" data-icon="ShoppingBag" data-size="20px" data-weight="regular">
@@ -69,12 +69,12 @@
                 ></path>
               </svg>
             </div>
-          </button>
+          </a>
         </div>
-        <div
+        <a href="login.html"
                 class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
                 style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuAni_KViwDhS6axE_n5DRbaCxwaq33bC_edJSs2XobAIbec1DmbFoxvtfYlGELN0OQUa_iaYCEhxs7-Ry798MI1g102RhsME3gKdVVfVOmD1INGKRrW8V2tiQJMV0pViRwPwiPyIC29BLGQjETU0-MwaX2DA9ZopE6gbLqveLEJqw7j0q8rw4Ak_nz7Qgo6UghAVLpcRJ-wQsQV-iYa6Y-Cm8-wnvmfvrVyWJsylEI0GdhBfdH2VJXNTbMdWEWHgQZ756jjxJ9E6mY");'
-        ></div>
+        ></a>
       </div>
     </header>
     <div class="px-40 flex flex-1 justify-center py-5">

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -32,7 +32,7 @@
               </div>
             </div>
             <div class="flex flex-col gap-2">
-              <div class="flex items-center gap-3 px-3 py-2 rounded-lg bg-[#f2f2f2]">
+              <a href="dashboard.html" class="flex items-center gap-3 px-3 py-2 rounded-lg bg-[#f2f2f2]">
                 <div class="text-[#141414]" data-icon="House" data-size="24px" data-weight="fill">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -41,8 +41,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Dashboard</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="magazzino.html" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="SquaresFour" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -51,8 +51,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Products</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="ordiniArtigiano.html" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="Receipt" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -61,8 +61,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Orders</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="#" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="ChartLine" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -71,8 +71,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Analytics</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="#" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="Gear" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -81,7 +81,7 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Settings</p>
-              </div>
+              </a>
             </div>
           </div>
         </div>
@@ -195,7 +195,7 @@
                   </button>
                 </td>
                 <td class="table-a11663c8-d34f-4f17-a716-6de644679ea9-column-600 h-[72px] px-4 py-2 w-60 text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">
-                  Edit
+                  <a href="aggiungiProdotto.html">Edit</a>
                 </td>
               </tr>
               <tr class="border-t border-t-[#e0e0e0]">
@@ -212,7 +212,7 @@
                   </button>
                 </td>
                 <td class="table-a11663c8-d34f-4f17-a716-6de644679ea9-column-600 h-[72px] px-4 py-2 w-60 text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">
-                  Edit
+                  <a href="aggiungiProdotto.html">Edit</a>
                 </td>
               </tr>
               <tr class="border-t border-t-[#e0e0e0]">
@@ -229,7 +229,7 @@
                   </button>
                 </td>
                 <td class="table-a11663c8-d34f-4f17-a716-6de644679ea9-column-600 h-[72px] px-4 py-2 w-60 text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">
-                  Edit
+                  <a href="aggiungiProdotto.html">Edit</a>
                 </td>
               </tr>
               <tr class="border-t border-t-[#e0e0e0]">
@@ -246,7 +246,7 @@
                   </button>
                 </td>
                 <td class="table-a11663c8-d34f-4f17-a716-6de644679ea9-column-600 h-[72px] px-4 py-2 w-60 text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">
-                  Edit
+                  <a href="aggiungiProdotto.html">Edit</a>
                 </td>
               </tr>
               <tr class="border-t border-t-[#e0e0e0]">
@@ -263,7 +263,7 @@
                   </button>
                 </td>
                 <td class="table-a11663c8-d34f-4f17-a716-6de644679ea9-column-600 h-[72px] px-4 py-2 w-60 text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">
-                  Edit
+                  <a href="aggiungiProdotto.html">Edit</a>
                 </td>
               </tr>
               </tbody>

--- a/public/dettaglioOrdineArtigiano.html
+++ b/public/dettaglioOrdineArtigiano.html
@@ -26,7 +26,7 @@
                             <p class="text-[#757575] text-sm font-normal leading-normal">Handmade Haven</p>
                         </div>
                         <div class="flex flex-col gap-2">
-                            <div class="flex items-center gap-3 px-3 py-2">
+                            <a href="dashboard.html" class="flex items-center gap-3 px-3 py-2">
                                 <div class="text-[#141414]" data-icon="House" data-size="24px" data-weight="regular">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                                         <path
@@ -35,8 +35,8 @@
                                     </svg>
                                 </div>
                                 <p class="text-[#141414] text-sm font-medium leading-normal">Dashboard</p>
-                            </div>
-                            <div class="flex items-center gap-3 px-3 py-2">
+                            </a>
+                            <a href="ordiniArtigiano.html" class="flex items-center gap-3 px-3 py-2">
                                 <div class="text-[#141414]" data-icon="Package" data-size="24px" data-weight="regular">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                                         <path
@@ -45,8 +45,8 @@
                                     </svg>
                                 </div>
                                 <p class="text-[#141414] text-sm font-medium leading-normal">Orders</p>
-                            </div>
-                            <div class="flex items-center gap-3 px-3 py-2 rounded-full bg-[#f2f2f2]">
+                            </a>
+                            <a href="magazzino.html" class="flex items-center gap-3 px-3 py-2 rounded-full bg-[#f2f2f2]">
                                 <div class="text-[#141414]" data-icon="SquaresFour" data-size="24px" data-weight="fill">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                                         <path
@@ -55,8 +55,8 @@
                                     </svg>
                                 </div>
                                 <p class="text-[#141414] text-sm font-medium leading-normal">Products</p>
-                            </div>
-                            <div class="flex items-center gap-3 px-3 py-2">
+                            </a>
+                            <a href="#" class="flex items-center gap-3 px-3 py-2">
                                 <div class="text-[#141414]" data-icon="Users" data-size="24px" data-weight="regular">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                                         <path
@@ -65,8 +65,8 @@
                                     </svg>
                                 </div>
                                 <p class="text-[#141414] text-sm font-medium leading-normal">Customers</p>
-                            </div>
-                            <div class="flex items-center gap-3 px-3 py-2">
+                            </a>
+                            <a href="#" class="flex items-center gap-3 px-3 py-2">
                                 <div class="text-[#141414]" data-icon="ChartLine" data-size="24px" data-weight="regular">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                                         <path
@@ -75,7 +75,7 @@
                                     </svg>
                                 </div>
                                 <p class="text-[#141414] text-sm font-medium leading-normal">Analytics</p>
-                            </div>
+                            </a>
                         </div>
                     </div>
                 </div>
@@ -83,11 +83,11 @@
             <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
                 <div class="flex flex-wrap justify-between gap-3 p-4">
                     <p class="text-[#141414] tracking-light text-[32px] font-bold leading-tight min-w-72">Products</p>
-                    <button
+                    <a href="aggiungiProdotto.html"
                             class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-8 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-medium leading-normal"
                     >
                         <span class="truncate">Add Product</span>
-                    </button>
+                    </a>
                 </div>
                 <div class="px-4 py-3">
                     <label class="flex flex-col min-w-40 h-12 w-full">

--- a/public/index.html
+++ b/public/index.html
@@ -42,10 +42,10 @@
           <h2 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em]">Crafted</h2>
         </div>
         <div class="flex items-center gap-9">
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Home</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Artisans</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Products</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">About Us</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="index.html">Home</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="magazzino.html">Artisans</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="catalogo.html">Products</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="about.html">About Us</a>
         </div>
       </div>
       <div class="flex flex-1 justify-end gap-8">
@@ -71,9 +71,7 @@
           </div>
         </label>
         <div class="flex gap-2">
-          <button
-                  class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
-          >
+          <a href="#" class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5">
             <div class="text-[#141414]" data-icon="Heart" data-size="20px" data-weight="regular">
               <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
                 <path
@@ -81,10 +79,8 @@
                 ></path>
               </svg>
             </div>
-          </button>
-          <button
-                  class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
-          >
+          </a>
+          <a href="carrello.html" class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#f2f2f2] text-[#141414] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5">
             <div class="text-[#141414]" data-icon="ShoppingBag" data-size="20px" data-weight="regular">
               <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
                 <path
@@ -92,12 +88,9 @@
                 ></path>
               </svg>
             </div>
-          </button>
+          </a>
         </div>
-        <div
-                class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-                style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuAV_TrFrEf8dAIyrUavWWgS7t91uVSL1T7rCUtAkjVGBfGqeVeMsQnAho3Ww32-xV-Vi71hf6Y9WBuOr1YeKsQNpndNVKprVGHwpa_iMNZ4I9IrOutUXL9qcn-rIZYTxl7h8R0JA-oQuNpu15ZHlXiw1-qPEPUYhK6XDC3GZGSxc0b2R83pSl_JmzYfD9Zebzm_iC6opIzAVfiH6dO8KgabUxg_04x45mj6YoRwCLQgARI6VwYa4_653287h2oYXiQlle7uA6o1Ht4");'
-        ></div>
+        <a href="login.html" class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10" style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuAV_TrFrEf8dAIyrUavWWgS7t91uVSL1T7rCUtAkjVGBfGqeVeMsQnAho3Ww32-xV-Vi71hf6Y9WBuOr1YeKsQNpndNVKprVGHwpa_iMNZ4I9IrOutUXL9qcn-rIZYTxl7h8R0JA-oQuNpu15ZHlXiw1-qPEPUYhK6XDC3GZGSxc0b2R83pSl_JmzYfD9Zebzm_iC6opIzAVfiH6dO8KgabUxg_04x45mj6YoRwCLQgARI6VwYa4_653287h2oYXiQlle7uA6o1Ht4");'></a>
       </div>
     </header>
     <div class="px-40 flex flex-1 justify-center py-5">
@@ -118,11 +111,11 @@
                   Support local artisans and find one-of-a-kind treasures.
                 </h2>
               </div>
-              <button
+              <a href="catalogo.html"
                       class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 px-4 @[480px]:h-12 @[480px]:px-5 bg-black text-white text-sm font-bold leading-normal tracking-[0.015em] @[480px]:text-base @[480px]:font-bold @[480px]:leading-normal @[480px]:tracking-[0.015em]"
               >
                 <span class="truncate">Shop Now</span>
-              </button>
+              </a>
             </div>
           </div>
         </div>
@@ -247,9 +240,9 @@
         </div>
         <footer class="flex flex-col gap-6 px-5 py-10 text-center @container">
           <div class="flex flex-wrap items-center justify-center gap-6 @[480px]:flex-row @[480px]:justify-around">
-            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="#">Contact Us</a>
-            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="#">Privacy Policy</a>
-            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="#">Terms of Service</a>
+            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="contatti.html">Contact Us</a>
+            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="privacy.html">Privacy Policy</a>
+            <a class="text-[#757575] text-base font-normal leading-normal min-w-40" href="terms.html">Terms of Service</a>
           </div>
           <div class="flex flex-wrap justify-center gap-4">
             <a href="#">

--- a/public/login.html
+++ b/public/login.html
@@ -42,16 +42,16 @@
       </div>
       <div class="flex flex-1 justify-end gap-8">
         <div class="flex items-center gap-9">
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Home</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Shop</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">About</a>
-          <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Contact</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="index.html">Home</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="catalogo.html">Shop</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="about.html">About</a>
+          <a class="text-[#141414] text-sm font-medium leading-normal" href="contatti.html">Contact</a>
         </div>
-        <button
+        <a href="registrazione.html"
                 class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-bold leading-normal tracking-[0.015em]"
         >
           <span class="truncate">Sign up</span>
-        </button>
+        </a>
       </div>
     </header>
     <div class="px-40 flex flex-1 justify-center py-5">
@@ -77,7 +77,7 @@
             />
           </label>
         </div>
-        <p class="text-[#757575] text-sm font-normal leading-normal pb-3 pt-1 px-4 underline">Forgot password?</p>
+        <a href="#" class="text-[#757575] text-sm font-normal leading-normal pb-3 pt-1 px-4 underline">Forgot password?</a>
         <div class="flex px-4 py-3">
           <button
                   class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 px-4 flex-1 bg-black text-white text-sm font-bold leading-normal tracking-[0.015em]"
@@ -85,11 +85,10 @@
             <span class="truncate">Log in</span>
           </button>
         </div>
-        <p class="text-[#757575] text-sm font-normal leading-normal pb-3 pt-1 px-4 text-center underline">Don't have an account? Sign up</p>
+        <a href="registrazione.html" class="text-[#757575] text-sm font-normal leading-normal pb-3 pt-1 px-4 text-center underline">Don't have an account? Sign up</a>
       </div>
     </div>
   </div>
 </div>
 </body>
 </html>
->

--- a/public/magazzino.html
+++ b/public/magazzino.html
@@ -26,7 +26,7 @@
               <p class="text-[#757575] text-sm font-normal leading-normal">Handmade Haven</p>
             </div>
             <div class="flex flex-col gap-2">
-              <div class="flex items-center gap-3 px-3 py-2">
+              <a href="dashboard.html" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="House" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -35,8 +35,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Dashboard</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="ordiniArtigiano.html" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="Package" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -45,8 +45,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Orders</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2 rounded-full bg-[#f2f2f2]">
+              </a>
+              <a href="magazzino.html" class="flex items-center gap-3 px-3 py-2 rounded-full bg-[#f2f2f2]">
                 <div class="text-[#141414]" data-icon="SquaresFour" data-size="24px" data-weight="fill">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -55,8 +55,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Products</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="#" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="Users" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -65,8 +65,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Customers</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="#" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="ChartLine" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -75,7 +75,7 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Analytics</p>
-              </div>
+              </a>
             </div>
           </div>
         </div>
@@ -83,11 +83,11 @@
       <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
         <div class="flex flex-wrap justify-between gap-3 p-4">
           <p class="text-[#141414] tracking-light text-[32px] font-bold leading-tight min-w-72">Products</p>
-          <button
+          <a href="aggiungiProdotto.html"
                   class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-8 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-medium leading-normal"
           >
             <span class="truncate">Add Product</span>
-          </button>
+          </a>
         </div>
         <div class="px-4 py-3">
           <label class="flex flex-col min-w-40 h-12 w-full">

--- a/public/ordiniArtigiano.html
+++ b/public/ordiniArtigiano.html
@@ -26,7 +26,7 @@
               <p class="text-[#757575] text-sm font-normal leading-normal">Handmade Haven</p>
             </div>
             <div class="flex flex-col gap-2">
-              <div class="flex items-center gap-3 px-3 py-2">
+              <a href="dashboard.html" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="House" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -35,8 +35,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Dashboard</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="ordiniArtigiano.html" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="Package" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -45,8 +45,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Orders</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2 rounded-full bg-[#f2f2f2]">
+              </a>
+              <a href="magazzino.html" class="flex items-center gap-3 px-3 py-2 rounded-full bg-[#f2f2f2]">
                 <div class="text-[#141414]" data-icon="SquaresFour" data-size="24px" data-weight="fill">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -55,8 +55,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Products</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="#" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="Users" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -65,8 +65,8 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Customers</p>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
+              </a>
+              <a href="#" class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#141414]" data-icon="ChartLine" data-size="24px" data-weight="regular">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                     <path
@@ -75,178 +75,114 @@
                   </svg>
                 </div>
                 <p class="text-[#141414] text-sm font-medium leading-normal">Analytics</p>
-              </div>
+              </a>
             </div>
           </div>
         </div>
       </div>
       <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
         <div class="flex flex-wrap justify-between gap-3 p-4">
-          <p class="text-[#141414] tracking-light text-[32px] font-bold leading-tight min-w-72">Products</p>
-          <button
+          <p class="text-[#141414] tracking-light text-[32px] font-bold leading-tight min-w-72">Orders</p> <!-- Corrected Title -->
+          <a href="aggiungiProdotto.html"
                   class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-8 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-medium leading-normal"
           >
             <span class="truncate">Add Product</span>
-          </button>
+          </a>
         </div>
-        <div class="px-4 py-3">
-          <label class="flex flex-col min-w-40 h-12 w-full">
-            <div class="flex w-full flex-1 items-stretch rounded-xl h-full">
-              <div
-                      class="text-[#757575] flex border-none bg-[#f2f2f2] items-center justify-center pl-4 rounded-l-xl border-r-0"
-                      data-icon="MagnifyingGlass"
-                      data-size="24px"
-                      data-weight="regular"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                  <path
-                          d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"
-                  ></path>
-                </svg>
-              </div>
-              <input
-                      placeholder="Search products"
-                      class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border-none bg-[#f2f2f2] focus:border-none h-full placeholder:text-[#757575] px-4 rounded-l-none border-l-0 pl-2 text-base font-normal leading-normal"
-                      value=""
-              />
-            </div>
-          </label>
-        </div>
-        <h2 class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">Stock Alerts</h2>
-        <div class="px-4 py-3 @container">
-          <div class="flex overflow-hidden rounded-xl border border-[#e0e0e0] bg-white">
-            <table class="flex-1">
-              <thead>
-              <tr class="bg-white">
-                <th class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-120 px-4 py-3 text-left text-[#141414] w-[400px] text-sm font-medium leading-normal">Product</th>
-                <th class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-240 px-4 py-3 text-left text-[#141414] w-[400px] text-sm font-medium leading-normal">Stock</th>
-                <th class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-360 px-4 py-3 text-left text-[#141414] w-[400px] text-sm font-medium leading-normal">
-                  Alert Threshold
-                </th>
-              </tr>
-              </thead>
-              <tbody>
-              <tr class="border-t border-t-[#e0e0e0]">
-                <td class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-120 h-[72px] px-4 py-2 w-[400px] text-[#141414] text-sm font-normal leading-normal">
-                  Hand-Painted Ceramic Mug
-                </td>
-                <td class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-240 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">5</td>
-                <td class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-360 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">10</td>
-              </tr>
-              <tr class="border-t border-t-[#e0e0e0]">
-                <td class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-120 h-[72px] px-4 py-2 w-[400px] text-[#141414] text-sm font-normal leading-normal">
-                  Woven Cotton Scarf
-                </td>
-                <td class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-240 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">2</td>
-                <td class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-360 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">5</td>
-              </tr>
-              <tr class="border-t border-t-[#e0e0e0]">
-                <td class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-120 h-[72px] px-4 py-2 w-[400px] text-[#141414] text-sm font-normal leading-normal">
-                  Artisan Soap Set
-                </td>
-                <td class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-240 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">3</td>
-                <td class="table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-360 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">5</td>
-              </tr>
-              </tbody>
-            </table>
+        <div class="pb-3">
+          <div class="flex border-b border-[#e0e0e0] px-4 gap-8">
+            <a class="flex flex-col items-center justify-center border-b-[3px] border-b-[#141414] text-[#141414] pb-[13px] pt-4" href="ordiniArtigiano.html">
+              <p class="text-[#141414] text-sm font-bold leading-normal tracking-[0.015em]">All</p>
+            </a>
+            <a class="flex flex-col items-center justify-center border-b-[3px] border-b-transparent text-[#757575] pb-[13px] pt-4" href="#">
+              <p class="text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">Pending</p>
+            </a>
+            <a class="flex flex-col items-center justify-center border-b-[3px] border-b-transparent text-[#757575] pb-[13px] pt-4" href="#">
+              <p class="text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">Shipped</p>
+            </a>
+            <a class="flex flex-col items-center justify-center border-b-[3px] border-b-transparent text-[#757575] pb-[13px] pt-4" href="#">
+              <p class="text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">Delivered</p>
+            </a>
+            <a class="flex flex-col items-center justify-center border-b-[3px] border-b-transparent text-[#757575] pb-[13px] pt-4" href="#">
+              <p class="text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">Cancelled</p>
+            </a>
           </div>
-          <style>
-            @container(max-width:120px){.table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-120{display: none;}}
-            @container(max-width:240px){.table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-240{display: none;}}
-            @container(max-width:360px){.table-73b6bc3f-19d1-499a-a8e7-e04c417bdbad-column-360{display: none;}}
-          </style>
         </div>
-        <h2 class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">All Products</h2>
         <div class="px-4 py-3 @container">
           <div class="flex overflow-hidden rounded-xl border border-[#e0e0e0] bg-white">
             <table class="flex-1">
               <thead>
               <tr class="bg-white">
-                <th class="table-56596f31-6753-401f-8311-c34cf551a185-column-120 px-4 py-3 text-left text-[#141414] w-[400px] text-sm font-medium leading-normal">Product</th>
-                <th class="table-56596f31-6753-401f-8311-c34cf551a185-column-240 px-4 py-3 text-left text-[#141414] w-[400px] text-sm font-medium leading-normal">Stock</th>
-                <th class="table-56596f31-6753-401f-8311-c34cf551a185-column-360 px-4 py-3 text-left text-[#141414] w-[400px] text-sm font-medium leading-normal">Price</th>
-                <th class="table-56596f31-6753-401f-8311-c34cf551a185-column-480 px-4 py-3 text-left text-[#141414] w-60 text-sm font-medium leading-normal">Status</th>
+                <th class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-120 px-4 py-3 text-left text-[#141414] w-[400px] text-sm font-medium leading-normal">Order ID</th>
+                <th class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-240 px-4 py-3 text-left text-[#141414] w-[400px] text-sm font-medium leading-normal">Date</th>
+                <th class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-360 px-4 py-3 text-left text-[#141414] w-[400px] text-sm font-medium leading-normal">Customer</th>
+                <th class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-480 px-4 py-3 text-left text-[#141414] w-60 text-sm font-medium leading-normal">Status</th>
+                <th class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-600 px-4 py-3 text-left text-[#141414] w-60 text-sm font-medium leading-normal">Actions</th>
               </tr>
               </thead>
               <tbody>
               <tr class="border-t border-t-[#e0e0e0]">
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-120 h-[72px] px-4 py-2 w-[400px] text-[#141414] text-sm font-normal leading-normal">
-                  Hand-Painted Ceramic Mug
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-120 h-[72px] px-4 py-2 w-[400px] text-[#141414] text-sm font-normal leading-normal">#12345</td>
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-240 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">
+                  July 15, 2024
                 </td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-240 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">15</td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-360 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">$25</td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-360 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">John Doe</td>
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
                   <button
                           class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-8 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-medium leading-normal w-full"
                   >
-                    <span class="truncate">Active</span>
+                    <span class="truncate">Shipped</span>
                   </button>
+                </td>
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-600 h-[72px] px-4 py-2 w-60 text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">
+                  <a href="dettaglioOrdineArtigiano.html">View Details</a>
                 </td>
               </tr>
               <tr class="border-t border-t-[#e0e0e0]">
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-120 h-[72px] px-4 py-2 w-[400px] text-[#141414] text-sm font-normal leading-normal">
-                  Woven Cotton Scarf
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-120 h-[72px] px-4 py-2 w-[400px] text-[#141414] text-sm font-normal leading-normal">#12346</td>
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-240 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">
+                  July 10, 2024
                 </td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-240 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">8</td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-360 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">$40</td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-360 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">Jane Smith</td>
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
                   <button
                           class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-8 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-medium leading-normal w-full"
                   >
-                    <span class="truncate">Active</span>
+                    <span class="truncate">Delivered</span>
                   </button>
+                </td>
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-600 h-[72px] px-4 py-2 w-60 text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">
+                  <a href="dettaglioOrdineArtigiano.html">View Details</a>
                 </td>
               </tr>
               <tr class="border-t border-t-[#e0e0e0]">
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-120 h-[72px] px-4 py-2 w-[400px] text-[#141414] text-sm font-normal leading-normal">
-                  Artisan Soap Set
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-120 h-[72px] px-4 py-2 w-[400px] text-[#141414] text-sm font-normal leading-normal">#12347</td>
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-240 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">
+                  July 5, 2024
                 </td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-240 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">12</td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-360 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">$15</td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-360 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">
+                  Robert Johnson
+                </td>
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
                   <button
                           class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-8 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-medium leading-normal w-full"
                   >
-                    <span class="truncate">Active</span>
+                    <span class="truncate">Cancelled</span>
                   </button>
                 </td>
-              </tr>
-              <tr class="border-t border-t-[#e0e0e0]">
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-120 h-[72px] px-4 py-2 w-[400px] text-[#141414] text-sm font-normal leading-normal">
-                  Leather Journal
-                </td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-240 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">20</td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-360 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">$30</td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
-                  <button
-                          class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-8 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-medium leading-normal w-full"
-                  >
-                    <span class="truncate">Active</span>
-                  </button>
-                </td>
-              </tr>
-              <tr class="border-t border-t-[#e0e0e0]">
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-120 h-[72px] px-4 py-2 w-[400px] text-[#141414] text-sm font-normal leading-normal">
-                  Wooden Coaster Set
-                </td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-240 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">5</td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-360 h-[72px] px-4 py-2 w-[400px] text-[#757575] text-sm font-normal leading-normal">$20</td>
-                <td class="table-56596f31-6753-401f-8311-c34cf551a185-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
-                  <button
-                          class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-8 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-medium leading-normal w-full"
-                  >
-                    <span class="truncate">Active</span>
-                  </button>
+                <td class="table-db523c37-589e-4128-8b76-f0f9a35f759f-column-600 h-[72px] px-4 py-2 w-60 text-[#757575] text-sm font-bold leading-normal tracking-[0.015em]">
+                  <a href="dettaglioOrdineArtigiano.html">View Details</a>
                 </td>
               </tr>
               </tbody>
             </table>
           </div>
           <style>
-            @container(max-width:120px){.table-56596f31-6753-401f-8311-c34cf551a185-column-120{display: none;}}
-            @container(max-width:240px){.table-56596f31-6753-401f-8311-c34cf551a185-column-240{display: none;}}
-            @container(max-width:360px){.table-56596f31-6753-401f-8311-c34cf551a185-column-360{display: none;}}
-            @container(max-width:480px){.table-56596f31-6753-401f-8311-c34cf551a185-column-480{display: none;}}
+            @container(max-width:120px){.table-db523c37-589e-4128-8b76-f0f9a35f759f-column-120{display: none;}}
+            @container(max-width:240px){.table-db523c37-589e-4128-8b76-f0f9a35f759f-column-240{display: none;}}
+            @container(max-width:360px){.table-db523c37-589e-4128-8b76-f0f9a35f759f-column-360{display: none;}}
+            @container(max-width:480px){.table-db523c37-589e-4128-8b76-f0f9a35f759f-column-480{display: none;}}
+            @container(max-width:600px){.table-db523c37-589e-4128-8b76-f0f9a35f759f-column-600{display: none;}}
           </style>
         </div>
       </div>

--- a/public/registrazione.html
+++ b/public/registrazione.html
@@ -26,15 +26,17 @@
             </div>
             <div class="flex flex-1 justify-end gap-8">
                 <div class="flex items-center gap-9">
-                    <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Home</a>
-                    <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Shop</a>
-                    <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Artisans</a>
+                    <a class="text-[#141414] text-sm font-medium leading-normal" href="index.html">Home</a>
+                    <a class="text-[#141414] text-sm font-medium leading-normal" href="catalogo.html">Shop</a>
+                    <a class="text-[#141414] text-sm font-medium leading-normal" href="magazzino.html">Artisans</a>
                 </div>
-                <button
-                        class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-bold leading-normal tracking-[0.015em]"
-                >
-                    <span class="truncate">Login</span>
-                </button>
+                <a href="login.html">
+                    <button
+                            class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#f2f2f2] text-[#141414] text-sm font-bold leading-normal tracking-[0.015em]"
+                    >
+                        <span class="truncate">Login</span>
+                    </button>
+                </a>
             </div>
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">
@@ -93,7 +95,7 @@
                         <span class="truncate">Sign Up</span>
                     </button>
                 </div>
-                <p class="text-[#757575] text-sm font-normal leading-normal pb-3 pt-1 px-4 text-center underline">Already have an account? Log in</p>
+                <a href="login.html" class="text-[#757575] text-sm font-normal leading-normal pb-3 pt-1 px-4 text-center underline">Already have an account? Log in</a>
             </div>
         </div>
     </div>

--- a/server.js
+++ b/server.js
@@ -11,6 +11,35 @@ require('./models/Cart');
 require('./models/Order');
 require('./models/OrderItem');
 
+// Define Associations
+const { User, Artisan, Product, Cart, Order, OrderItem } = sequelize.models;
+
+// Artisan associations
+Artisan.belongsTo(User, { foreignKey: 'userId' });
+Artisan.hasMany(Product, { foreignKey: 'artisanId' });
+
+// User associations
+User.hasMany(Cart, { foreignKey: 'userId' });
+User.hasMany(Order, { foreignKey: 'userId' });
+User.hasOne(Artisan, { foreignKey: 'userId' });
+
+// Product associations
+Product.belongsTo(Artisan, { foreignKey: 'artisanId' });
+Product.hasMany(Cart, { foreignKey: 'productId' });
+Product.hasMany(OrderItem, { foreignKey: 'productId' });
+
+// Cart associations
+Cart.belongsTo(User, { foreignKey: 'userId' });
+Cart.belongsTo(Product, { foreignKey: 'productId' });
+
+// Order associations
+Order.belongsTo(User, { foreignKey: 'userId' });
+Order.hasMany(OrderItem, { foreignKey: 'orderId' });
+
+// OrderItem associations
+OrderItem.belongsTo(Order, { foreignKey: 'orderId' });
+OrderItem.belongsTo(Product, { foreignKey: 'productId' });
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 


### PR DESCRIPTION
- I decoupled association definitions from model files to prevent circular dependencies.
- I centralized all Sequelize model associations in server.js.
- I corrected href attributes in all public HTML files to ensure proper site navigation.

Note: Full testing could not be completed due to a persistent issue with the 'express' module reported as missing in the test environment, even after an 'npm install' step.